### PR TITLE
1.9.0d release - HIPAA Eligible Services changes June 2025. Added qdeveloper:*. Fix type in main README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The **Landing Zone Accelerator (LZA) for Healthcare** is an industry specific de
 
 ## Security Frameworks
 
-The healthcare industry is high regulated. The LZA for Healthcare provides additional guardrails to help mitigate against the threats faced by healthcare customers. The LZA for Healthcare is not meant to be feature complete for fully compliant, but rather is intended to help accelerate cloud migrations and cloud refactoring efforts by organizations serving the healthcare industry. While much effort has been made to reduce the effort required to manually build a production-ready infrastructure, you will still need to tailor it to your unique business needs.
+The healthcare industry is highly regulated. The LZA for Healthcare provides additional guardrails to help mitigate against the threats faced by healthcare customers. The LZA for Healthcare is not meant to be feature complete for fully compliant, but rather is intended to help accelerate cloud migrations and cloud refactoring efforts by organizations serving the healthcare industry. While much effort has been made to reduce the effort required to manually build a production-ready infrastructure, you will still need to tailor it to your unique business needs.
 
 This solution includes controls from frameworks in various geographies, including HIPAA, NCSC, ENS High, C5, and Fascicolo Sanitario Elettronico. If you are deploying the Landing Zone Accelerator on AWS for Healthcare solution, please consult with your AWS team to understand controls to meet your requirements.
 
@@ -183,7 +183,6 @@ This library is licensed under the MIT-0 License. See the [LICENSE](LICENSE) fil
   - Updates config/service-control-policies/scp-hcl-hipaa-service.json and config/service-control-policies/Readme.md to reflect HIPAA Eligible Services list changes as of 12/2024.
 - Bug fixes: None
 
-
 ### v1.9.0-c - 5/17/2025
 - Changes: 
   - 2/2025
@@ -197,4 +196,12 @@ This library is licensed under the MIT-0 License. See the [LICENSE](LICENSE) fil
   - Add Tools Monitoring / Telemetry. 
         - APIs pi:* and applicationinsights:*
   - Update to reflect 4/16/2025 HIPAA Eligible Services List 
+- Bug fixes: None
+
+### v1.9.0-d - 6/17/2025
+- Changes: 
+  - 6/2025
+    - Renames AWS Security Hub to AWS Security Hub CSPM (formerly AWS Security Hub)
+    - Adds tool API qdeveloper:*
+    - Fixes type in main README "high regulated" to "highly regulated"
 - Bug fixes: None

--- a/config/service-control-policies/Readme.md
+++ b/config/service-control-policies/Readme.md
@@ -2,7 +2,7 @@
 
 baseline-guardrails-hipaa.json file contains the Service Control Policies (SCPs) that can be deployed while building HIPAA eligible environments.
 
-HIPAA Eligible Services are last updated on April 16, 2025.
+HIPAA Eligible Services are last updated on June 17, 2025.
 
 Here are some statistics about the SCPs:
 
@@ -150,7 +150,7 @@ Amazon Route 53 \
 Amazon S3 Glacier \
 Amazon SageMaker AI [formerly Amazon Sagemaker, excludes Studio Lab, Ground Truth Plus, Public Workforce and Vendor Workforce for all features] \
 AWS Secrets Manager \
-AWS Security Hub \
+AWS Security Hub CSPM (formerly AWS Security Hub) \
 AWS Service Catalog \
 AWS Serverless Application Repository \
 AWS Shield [Standard and Advanced] \
@@ -228,3 +228,7 @@ The featured scp-hcl-hipaa-service.json includes APIs for other tools / services
 
 - "apiname": "pi:\*"
 - "apiname": "applicationinsights:\*"
+
+### Service Catagory - Notable Tools not intended to store, process, or transmit PHI
+
+- "apiname": "qdeveloper:\*"

--- a/config/service-control-policies/scp-hcl-hipaa-service.json
+++ b/config/service-control-policies/scp-hcl-hipaa-service.json
@@ -2,7 +2,7 @@
 	"Version": "2012-10-17",
 	"Statement": [
 		{
-			"Sid": "HIPAAEligibleServices20250416",
+			"Sid": "HIPAAEligibleServices20250617",
 			"Effect": "Deny",
 			"NotAction": [
 				"a4b:*",
@@ -140,6 +140,7 @@
 				"polly:*",
 				"pricing:*",
 				"qbusiness:*",
+				"qdeveloper:*",
 				"qldb:*",
 				"quicksight:*",
 				"ram:*",


### PR DESCRIPTION
    - Renames AWS Security Hub to AWS Security Hub CSPM (formerly AWS Security Hub)
    - Adds tool API qdeveloper:*
    - Fixes type in main README "high regulated" to "highly regulated"