### PR TITLE
Standardize AcceleratorHomeRegion and quotes

### DIFF
--- a/config/global-config.yaml
+++ b/config/global-config.yaml
@@ -1,6 +1,6 @@
-homeRegion: &HOME_REGION us-east-1
+homeRegion: "{{AcceleratorHomeRegion}}"
 enabledRegions:
-  - *HOME_REGION
+  - "{{AcceleratorHomeRegion}}"
 managementAccountAccessRole: AWSControlTowerExecution
 cloudwatchLogRetentionInDays: 3653
 terminationProtection: true

--- a/config/network-config.yaml
+++ b/config/network-config.yaml
@@ -3,7 +3,7 @@
 # please review our network configuration reference in our README.md:             #
 # https://github.com/awslabs/landing-zone-accelerator-on-aws/blob/main/README.md  #
 ###################################################################################
-homeRegion: &HOME_REGION us-east-1
+homeRegion: "{{AcceleratorHomeRegion}}"
 #####################################
 # Delete default VPCs-- use this    #
 # object to delete default VPCs in  #
@@ -20,7 +20,7 @@ defaultVpc:
 transitGateways:
   - name: Network-Main
     account: Network-Prod
-    region: {{AcceleratorHomeRegion}}
+    region: "{{AcceleratorHomeRegion}}"
     shareTargets:
       organizationalUnits:
         - Infrastructure/Infra-Prod
@@ -65,7 +65,7 @@ endpointPolicies:
 vpcs:
   - name: Network-Endpoints
     account: Network-Prod
-    region: {{AcceleratorHomeRegion}}
+    region: "{{AcceleratorHomeRegion}}"
     cidrs:
       - 10.1.0.0/22
     defaultSecurityGroupRulesDeletion: true
@@ -154,7 +154,7 @@ vpcs:
         - service: logs
   - name: Network-Inspection
     account: Network-Prod
-    region: {{AcceleratorHomeRegion}}
+    region: "{{AcceleratorHomeRegion}}"
     cidrs:
       - 10.2.0.0/22
     defaultSecurityGroupRulesDeletion: true
@@ -236,7 +236,7 @@ vpcs:
       - key: Name
         value: EIS-Prod
     account: EIS-Prod
-    region: {{AcceleratorHomeRegion}}
+    region: "{{AcceleratorHomeRegion}}"
     cidrs:
       - 10.3.0.0/16
     defaultSecurityGroupRulesDeletion: true
@@ -310,7 +310,7 @@ vpcs:
       - key: Name
         value: HIS-Dev
     account: HIS-Dev
-    region: {{AcceleratorHomeRegion}}
+    region: "{{AcceleratorHomeRegion}}"
     cidrs:
       - 10.4.0.0/16
     defaultSecurityGroupRulesDeletion: true

--- a/config/security-config.yaml
+++ b/config/security-config.yaml
@@ -4,7 +4,7 @@
 # https://awslabs.github.io/landing-zone-accelerator-on-aws/classes/_aws_accelerator_config.SecurityConfig.html  #
 ##################################################################################################################
 
-homeRegion: &HOME_REGION us-east-1
+homeRegion: "{{AcceleratorHomeRegion}}"
 centralSecurityServices:
   delegatedAdminAccount: Audit
   ebsDefaultVolumeEncryption:
@@ -538,7 +538,7 @@ awsConfig:
 cloudWatch:
   metricSets:
     - regions:
-        - {{AcceleratorHomeRegion}}
+        - "{{AcceleratorHomeRegion}}"
       #####################################
       # With landing zone version 3.0, AWS Control Tower now supports organization-level AWS CloudTrail trails.                                          #
       # Going forward from landing zone 3.0, AWS Control Tower no longer will support account-level trails that AWS manages.                             #
@@ -643,7 +643,7 @@ cloudWatch:
           metricValue: "1"
   alarmSets:
     - regions:
-        - {{AcceleratorHomeRegion}}
+        - "{{AcceleratorHomeRegion}}"
       #####################################
       # With landing zone version 3.0, AWS Control Tower now supports organization-level AWS CloudTrail trails.                                          #
       # Going forward from landing zone 3.0, AWS Control Tower no longer will support account-level trails that AWS manages.                             #

--- a/documentation/2-install.md
+++ b/documentation/2-install.md
@@ -68,11 +68,11 @@ Using the IDE of your choice, in your local `aws-accelerator-config` repo, updat
 If you are changing the home region from _us-east-1_ to different region, you need to make the following configuration file modifications.
 
 - global-config.yaml
-  - **homeRegion: &HOME_REGION us-east-1** must be updated from _us-east-1_ to the region you are using as your home region (e.g. _homeRegion: &HOME_REGION us-west-2_)
+  - **homeRegion: "{{AcceleratorHomeRegion}}"** must be updated from _us-east-1_ to the region you are using as your home region (set in replacements-config.yaml or set as needed)
 - networking-config.yaml
-  - **homeRegion: &HOME_REGION us-east-1** must be updated from _us-east-1_ to the region you are using as your home region
+  - **homeRegion: "{{AcceleratorHomeRegion}}"** (set in replacements-config.yaml or set as needed)
 - security-config.yaml
-  - **homeRegion: &HOME_REGION us-east-1** must be updated from _us-east-1_ to the region you are using as your home region
+  - **homeRegion: "{{AcceleratorHomeRegion}}"** (set in replacements-config.yaml or set as needed)
   - Several included AWS Config rules are only available in US East (_us-east-1_) region and must be commented out or removed.
     - [cloudfront-origin-access-identity-enabled](https://docs.aws.amazon.com/config/latest/developerguide/cloudfront-origin-access-identity-enabled.html)
     - [cloudfront-security-policy-check](https://docs.aws.amazon.com/config/latest/developerguide/cloudfront-security-policy-check.html)


### PR DESCRIPTION
*Issue #:* none

*Description of changes:*

- This removes the HOME_REGION local variable and populates the variable managed in replacements-config.yaml;
- Added double quotes wherever the variable is referenced (needed to do this for the pipeline to complete);
- Updated a page in documentation which referenced HOME_REGION.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
